### PR TITLE
パッケージ作成のためのスクリプトを追加

### DIFF
--- a/archive.bat
+++ b/archive.bat
@@ -1,0 +1,3 @@
+@echo off
+dub build
+7za a -tzip moecoop.zip fukuro.exe LICENSE README.md resource libfreetype-6.dll


### PR DESCRIPTION
7zip を利用して，バイナリ配布用ファイルの作成を簡単にするためのスクリプト．
できれば OS 標準機能を使いたいけど，調べた限りではできないみたいだった．
