### PR TITLE
Linux用にフォントフェイスを追加

### DIFF
--- a/source/coop/view/main_frame.d
+++ b/source/coop/view/main_frame.d
@@ -35,7 +35,7 @@ version(Windows) {
     immutable defaultFontName = "Meiryo UI";
 }
 else version(linux) {
-    immutable defaultFontName = "源ノ角ゴシック JP";
+    immutable defaultFontName = "源ノ角ゴシック JP,VL ゴシック,Takaoゴシック";
 }
 else version(OSX) {
     immutable defaultFontName = "游ゴシック体";


### PR DESCRIPTION
Fix #12 

Fedora系標準日本語フォントのVLゴシックと、Debian系標準日本語フォントのTakaoゴシックを追加
